### PR TITLE
Major Changes Read Readme

### DIFF
--- a/backend/services/complex/complete-order/README.md
+++ b/backend/services/complex/complete-order/README.md
@@ -16,17 +16,19 @@ go run main.go
 
 <h4>URL</h4>
 
->http://127.0.0.1:7070/bulk/cancel/Kendrick #Store Cancel Order 
->http://127.0.0.1:7070/single/complete/Kendrick #Store Complete Order
+>http://127.0.0.1:7070/cancel/Kendrick #Store Cancel Order 
+>http://127.0.0.1:7070/complete/Kendrick #Store Complete Order
 
 <h4>Expected Payload</h4>
 
+//Gawd damn i really streamlined it a lot LOL
+//Rem Draw out the diagram tomrrow LMAO
 ```json
 {
-    "food" : "Grilled_Teriyaki_Chicken_Donburi",
-    "restaurant" : "Bricklane",
-    "id": "18", //this refers to queue id btw pls don't confuse
-    "price": 6.9
+    "order_id" : "909fff87-e51c-4ecf-aa18-0dba89e0c54f",
+    "restaurant" : "Nasi_Lemak_Ayam_Taliwang",
+    "status": "cancelled",
+    "total" : 7
 }
 ```
 

--- a/backend/services/simple/order/README.md
+++ b/backend/services/simple/order/README.md
@@ -24,9 +24,13 @@ bun --watch index.ts
         "order_id": "f2057454-490b-4c72-abc3-85d759a29a68",
         "user_id": "Subrah",
         "info": {
-        "items": [
-            { "qty": 2, "dish": "Grilled_Teriyaki_Chicken_Donburi", "price": 6.9 }
-        ]
+            "items": [
+                { 
+                    "qty": 2, 
+                    "dish": "Grilled_Teriyaki_Chicken_Donburi", 
+                    "price": 6.9 
+                }
+            ]
         },
         "status": "completed",
         "restaurant": "Bricklane",
@@ -53,7 +57,7 @@ bun --watch index.ts
         "user_id": "Ryan",
         "info": { "items": [{ "qty": 200, "dish": "Bulgogi_Tacos", "price": 16 }] },
         "status": "processing",
-        "restaurant": "Bircklane",
+        "restaurant": "Bricklane",
         "total": 16
     },
     {
@@ -103,9 +107,9 @@ Search by order id
         "info": {
         "items": [
             {
-            "qty": 1,
-            "dish": "Ayam_Penyet",
-            "price": 7
+                "qty": 1,
+                "dish": "Ayam_Penyet",
+                "price": 7
             }
         ]
         },

--- a/backend/services/simple/order/README.md
+++ b/backend/services/simple/order/README.md
@@ -97,22 +97,22 @@ Search by order id
 
 ```json
 [
-  {
-    "order_id": "909fff87-e51c-4ecf-aa18-0dba89e0c54f",
-    "user_id": "Ewan",
-    "info": {
-      "items": [
-        {
-          "qty": 1,
-          "dish": "Ayam_Penyet",
-          "price": 7
-        }
-      ]
-    },
-    "status": "cancelled",
-    "restaurant": "Nasi_Lemak_Ayam_Taliwang",
-    "total": 7
-  }
+    {
+        "order_id": "909fff87-e51c-4ecf-aa18-0dba89e0c54f",
+        "user_id": "Ewan",
+        "info": {
+        "items": [
+            {
+            "qty": 1,
+            "dish": "Ayam_Penyet",
+            "price": 7
+            }
+        ]
+        },
+        "status": "cancelled",
+        "restaurant": "Nasi_Lemak_Ayam_Taliwang",
+        "total": 7
+    }
 ]
 ```
 
@@ -129,43 +129,43 @@ Search by order id
 
 ```json
 [
-  {
-    "order_id": "4631fe98-2fa6-4da5-b695-7eeb6328715a",
-    "user_id": "Kendrick",
-    "info": {
-      "items": [
-        {
-          "qty": 2,
-          "dish": "Grilled_Teriyaki_Chicken_Donburi",
-          "price": 13.8
+    {
+        "order_id": "4631fe98-2fa6-4da5-b695-7eeb6328715a",
+        "user_id": "Kendrick",
+        "info": {
+        "items": [
+            {
+            "qty": 2,
+            "dish": "Grilled_Teriyaki_Chicken_Donburi",
+            "price": 13.8
+            },
+            {
+            "qty": 200,
+            "dish": "Bulgogi_Tacos",
+            "price": 1600
+            }
+        ]
         },
-        {
-          "qty": 200,
-          "dish": "Bulgogi_Tacos",
-          "price": 1600
-        }
-      ]
+        "status": "processing",
+        "restaurant": "Bricklane",
+        "total": 1613.8
     },
-    "status": "processing",
-    "restaurant": "Bricklane",
-    "total": 1613.8
-  },
-  {
-    "order_id": "c9ba07bb-7b45-40e3-9643-2a276d331e26",
-    "user_id": "Kendrick",
-    "info": {
-      "items": [
-        {
-          "qty": 1,
-          "dish": "Ayam_Penyet",
-          "price": 7
-        }
-      ]
-    },
-    "status": "processing",
-    "restaurant": "Nasi_Lemak_Ayam_Taliwang",
-    "total": 49
-  }
+    {
+        "order_id": "c9ba07bb-7b45-40e3-9643-2a276d331e26",
+        "user_id": "Kendrick",
+        "info": {
+        "items": [
+            {
+            "qty": 1,
+            "dish": "Ayam_Penyet",
+            "price": 7
+            }
+        ]
+        },
+        "status": "processing",
+        "restaurant": "Nasi_Lemak_Ayam_Taliwang",
+        "total": 49
+    }
 ]
 ```
 
@@ -182,43 +182,43 @@ Search by order id
 
 ```json
 [
-  {
-    "order_id": "4631fe98-2fa6-4da5-b695-7eeb6328715a",
-    "user_id": "Kendrick",
-    "info": {
-      "items": [
-        {
-          "qty": 2,
-          "dish": "Grilled_Teriyaki_Chicken_Donburi",
-          "price": 13.8
+    {
+        "order_id": "4631fe98-2fa6-4da5-b695-7eeb6328715a",
+        "user_id": "Kendrick",
+        "info": {
+        "items": [
+            {
+            "qty": 2,
+            "dish": "Grilled_Teriyaki_Chicken_Donburi",
+            "price": 13.8
+            },
+            {
+            "qty": 200,
+            "dish": "Bulgogi_Tacos",
+            "price": 1600
+            }
+        ]
         },
-        {
-          "qty": 200,
-          "dish": "Bulgogi_Tacos",
-          "price": 1600
-        }
-      ]
+        "status": "processing",
+        "restaurant": "Bricklane",
+        "total": 1613.8
     },
-    "status": "processing",
-    "restaurant": "Bricklane",
-    "total": 1613.8
-  },
-  {
-    "order_id": "f2057454-490b-4c72-abc3-85d759a29a68",
-    "user_id": "Subrah",
-    "info": {
-      "items": [
-        {
-          "qty": 2,
-          "dish": "Grilled_Teriyaki_Chicken_Donburi",
-          "price": 6.9
-        }
-      ]
-    },
-    "status": "completed",
-    "restaurant": "Bricklane",
-    "total": 6.9
-  }
+    {
+        "order_id": "f2057454-490b-4c72-abc3-85d759a29a68",
+        "user_id": "Subrah",
+        "info": {
+        "items": [
+            {
+            "qty": 2,
+            "dish": "Grilled_Teriyaki_Chicken_Donburi",
+            "price": 6.9
+            }
+        ]
+        },
+        "status": "completed",
+        "restaurant": "Bricklane",
+        "total": 6.9
+    }
 ]
 ```
 
@@ -248,21 +248,21 @@ Search by order id
 
 ```json
 [
-  {
-    "order_id": "f2057454-490b-4c72-abc3-85d759a29a68",
-    "user_id": "Subrah",
-    "info": {
-      "Bricklane": [
-        {
-          "qty": 2,
-          "dish": "Grilled_Teriyaki_Chicken_Donburi",
-          "price": 6.9
-        }
-      ]
-    },
-    "status": "completed",
-    "total": 6.9
-  }
+    {
+        "order_id": "f2057454-490b-4c72-abc3-85d759a29a68",
+        "user_id": "Subrah",
+        "info": {
+        "Bricklane": [
+            {
+            "qty": 2,
+            "dish": "Grilled_Teriyaki_Chicken_Donburi",
+            "price": 6.9
+            }
+        ]
+        },
+        "status": "completed",
+        "total": 6.9
+    }
 ]
 ```
 
@@ -287,35 +287,35 @@ Search by order id
 
 ```json
 {
-  "orderid": "4631fe98-2fa6-4da5-b695-7eeb6328715a",
-  "user_id": "Kendrick",
-  "info": {
-    "Bricklane": [
-      {
-        "qty": 2,
-        "dish": "Grilled_Teriyaki_Chicken_Donburi",
-        "price": 13.8
-      },
-      {
-        "qty": 200,
-        "dish": "Bulgogi_Tacos",
-        "price": 1600
-      }
-    ],
-    "Ayam Taliwang": [
-      {
-        "qty": 1,
-        "dish": "Ayam_Penyet",
-        "price": 7
-      }
-    ]
-  },
-  "status": "cancelled",
-  "total": 1620.8
+    "orderid": "4631fe98-2fa6-4da5-b695-7eeb6328715a",
+    "user_id": "Kendrick",
+    "info": {
+        "Bricklane": [
+            {
+                "qty": 2,
+                "dish": "Grilled_Teriyaki_Chicken_Donburi",
+                "price": 13.8
+            },
+            {
+                "qty": 200,
+                "dish": "Bulgogi_Tacos",
+                "price": 1600
+            }
+        ],
+        "Ayam Taliwang": [
+            {
+                "qty": 1,
+                "dish": "Ayam_Penyet",
+                "price": 7
+            }
+        ]
+    },
+    "status": "cancelled",
+    "total": 1620.8
 }
 ```
 
-<h2>Add Order </h2>
+<h2>Add Order</h2>
 <b><u>POST Request</u></b>
 
 > http://localhost:6369/add
@@ -328,19 +328,19 @@ Search by order id
 
 ```json
 {
-  "user_id": "Kendrick",
-  "info": {
-    "items": [
-      {
-        "qty": 10,
-        "dish": "Black_Angus_Shortribs_Curry",
-        "price": 16.9
-      }
-    ]
-  },
-  "status": "processing",
-  "restaurant": "Kuro_Kare",
-  "total": 169
+    "user_id": "Kendrick",
+    "info": {
+        "items": [
+            {
+                "qty": 10,
+                "dish": "Black_Angus_Shortribs_Curry",
+                "price": 16.9
+            }
+        ]
+    },
+    "status": "processing",
+    "restaurant": "Kuro_Kare",
+    "total": 169
 }
 ```
 
@@ -348,20 +348,20 @@ Search by order id
 
 ```json
 {
-  "order_id": "20cc894b-62a3-48e9-8d0c-65238f227b8e",
-  "user_id": "Kendrick",
-  "info": {
-    "items": [
-      {
-        "qty": 10,
-        "dish": "Black_Angus_Shortribs_Curry",
-        "price": 16.9
-      }
-    ]
-  },
-  "status": "processing",
-  "restaurant": "Kuro_Kare",
-  "total": 169
+    "order_id": "20cc894b-62a3-48e9-8d0c-65238f227b8e",
+    "user_id": "Kendrick",
+    "info": {
+        "items": [
+            {
+                "qty": 10,
+                "dish": "Black_Angus_Shortribs_Curry",
+                "price": 16.9
+            }
+        ]
+    },
+    "status": "processing",
+    "restaurant": "Kuro_Kare",
+    "total": 169
 }
 ```
 

--- a/backend/services/simple/queue/README.md
+++ b/backend/services/simple/queue/README.md
@@ -105,6 +105,31 @@ Queue Data Succesfully Sent 🚀🚀🚀🚀
 
 <h2>Adding Queue (User bought the food)</h2>
 
+> consider 
+> http://localhost:8008/add
+```json
+{
+    "food" : "Grilled_Teriyaki_Chicken_Donburi",
+    "restaurant" : "Bricklane",
+    "user_id": "Kendrick", // this refer to user id 
+    "order_id" : ""
+}
+```
+
+
+<h2>Delete Queue (User bought the food)</h2>
+
+> consider 
+> http://localhost:8008/delete
+```json
+{
+    "restaurant" : "Bricklane",
+    "id" : 2 
+}
+```
+
+
+
 >http://localhost:8008/dump OR http://127.0.0.1:8008/dump
 >POST Request
 

--- a/backend/services/simple/queue/README.md
+++ b/backend/services/simple/queue/README.md
@@ -30,7 +30,7 @@ deno compile -A -o runme main.js #very surpised it worked so well LOL
 
 <h2>Get All Queues</h2>
 
->http://localhost:8008//qStatus OR http://127.0.0.1:8008/qStatus
+>http://localhost:8008/qStatus OR http://127.0.0.1:8008/qStatus
 >GET Request
 
 >console
@@ -44,155 +44,169 @@ Queue Data Succesfully Sent 🚀🚀🚀🚀
 ```json
 {
     "data": {
-        "Bricklane": [
+        "khoon_coffeehouse_express": [],
+        "bricklane": [
             {
-                "id": 2,
-                "food": "Torched_Mentaiko_Fries",
-                "user_id": "Jun Wei",
-                "time": "2025-03-08T15:30:22.992916"
+                "id": 8,
+                "user_id": "Kendrick",
+                "time": "2025-03-09T16:12:29.471876",
+                "order_id": "098243"
+            },
+            {
+                "id": 16,
+                "user_id": "Kendrick",
+                "time": "2025-03-09T16:35:46.943265",
+                "order_id": "23890"
             },
             {
                 "id": 3,
-                "food": "Kimchi_Carbonara",
                 "user_id": "Dorothy",
-                "time": "2025-03-08T16:29:22.992916"
+                "time": "2025-03-08T16:29:22.992916",
+                "order_id": "2786"
+            },
+            {
+                "id": 2,
+                "user_id": "Jun Wei",
+                "time": "2025-03-08T15:30:22.992916",
+                "order_id": "31092"
+            },
+            {
+                "id": 9,
+                "user_id": "Kendrick",
+                "time": "2025-03-09T16:13:09.902114",
+                "order_id": "78132"
+            },
+            {
+                "id": 15,
+                "user_id": "Kendrick",
+                "time": "2025-03-09T16:21:54.112761",
+                "order_id": "974852"
             },
             {
                 "id": 4,
-                "food": "Korean_Fried_Chicken",
                 "user_id": "Jason",
-                "time": "2025-03-08T16:38:22.992916"
-            }
-        ],
-        "Chops": [
-            {
-                "id": 1,
-                "food": "Grilled_Meats",
-                "user_id": "Sweetha",
-                "time": "2025-03-08T13:34:22.992916"
+                "time": "2025-03-08T16:38:22.992916",
+                "order_id": "987243"
             },
             {
+                "id": 18,
+                "user_id": "Kendrick",
+                "time": "2025-03-16T06:19:58.119566",
+                "order_id": "9874"
+            }
+        ],
+        "chops": [
+            {
                 "id": 2,
-                "food": "Grilled_Lamb_Chop",
                 "user_id": "Lay Foo",
-                "time": "2025-03-08T13:35:10.992916"
+                "time": "2025-03-08T13:35:10.992916",
+                "order_id": "32809"
             },
             {
                 "id": 3,
-                "food": "Truffle_Fries",
                 "user_id": "Dory",
-                "time": "2025-03-08T13:35:18.992916"
+                "time": "2025-03-08T13:35:18.992916",
+                "order_id": "92483"
+            },
+            {
+                "id": 1,
+                "user_id": "Sweetha",
+                "time": "2025-03-08T13:34:22.992916",
+                "order_id": "984173"
             }
         ],
-        "Daijoubu": [],
-        "Ima_Sushi": [],
-        "Khoon_Coffeehouse_Express": [],
-        "King_Kong_Curry": [],
-        "Kuro_Kare": [],
-        "Nasi_Lemak_Ayam_Taliwang": [],
-        "ONALU_Bagel_Haus": [],
-        "Park_s_Kitchen": [],
-        "Pasta_Express": [],
-        "Supergreen": [],
-        "Turks_Kebab": []
+        "daijoubu": [],
+        "onalu_bagel_haus": [],
+        "park_s_kitchen": [],
+        "kuro_kare": [],
+        "nasi_lemak_ayam_taliwang": [
+            {
+                "id": 7,
+                "user_id": "Kendrick",
+                "time": "2025-03-20T16:42:48.643179",
+                "order_id": "c9ba07bb-7b45-40e3-9643-2a276d331e26"
+            }
+        ],
+        "pasta_express": [],
+        "turks_kebab": [],
+        "supergreen": [],
+        "ima_sushi": [],
+        "king_kong_curry": []
     },
     "type": "queue"
 }
 ```
 <h4>NOTE</h4> 
-- Queue will send the above output automatically to queue every 20000ms or 0.33min
-- Add/Deletion of queue will result in 
+<!-- - Queue will send the above output automatically to queue every 20000ms or 0.33min -->
+- Can also be manually called using get /qStatus
 
 <h2>Adding Queue (User bought the food)</h2>
 
-> consider 
 > http://localhost:8008/add
-```json
-{
-    "food" : "Grilled_Teriyaki_Chicken_Donburi",
-    "restaurant" : "Bricklane",
-    "user_id": "Kendrick", // this refer to user id 
-    "order_id" : ""
-}
-```
-
-
-<h2>Delete Queue (User bought the food)</h2>
-
-> consider 
-> http://localhost:8008/delete
-```json
-{
-    "restaurant" : "Bricklane",
-    "id" : 2 
-}
-```
-
-
-
->http://localhost:8008/dump OR http://127.0.0.1:8008/dump
->POST Request
 
 <h3>Expected Payload</h3>
 
 ```json
 {
-    "food" : "Grilled_Teriyaki_Chicken_Donburi",
-    "restaurant" : "Bricklane",
-    "id": "Kendrick", // this refer to user id 
-    "action": "add"
+    "restaurant" : "Nasi_Lemak_Ayam_Taliwang",
+    "user_id": "Ewan",
+    "order_id" : "909fff87-e51c-4ecf-aa18-0dba89e0c54f"
 }
 ```
 
 <h3>Expected Output</h3>
 
 >console print
+
+```bash
+Change detected in a table:
+Added (➕) Queue to Nasi_Lemak_Ayam_Taliwang
+```
 
 ```json
 {
     "message": "Added (➕) Queue to Bricklane",
     "data": [
         {
-            "id": 16,
-            "food": "Grilled_Teriyaki_Chicken_Donburi",
-            "user_id": "Kendrick",
-            "time": "2025-03-09T16:35:46.943265"
+            "queue_no": 9, //queue position
+            "user_id": "Ewan",
+            "time": "2025-03-20T16:43:56.440132",
+            "order_id": "909fff87-e51c-4ecf-aa18-0dba89e0c54f"
         }
     ]
 }
 ```
 
+- This will also send an update to socket.io
+
 >socket.io(server.js) data received
 
 ```json
 {
-    "restaurant": "Bricklane",
+    "restaurant": "Nasi_Lemak_Ayam_Taliwang",
     "data": [
         {
-            "id": 16,
-            "food": "Grilled_Teriyaki_Chicken_Donburi",
-            "user_id": "Kendrick",
-            "time": "2025-03-09T16:35:46.943265"
+            "queue_no": 9,
+            "user_id": "Ewan",
+            "time": "2025-03-20T16:43:56.440132",
+            "order_id": "909fff87-e51c-4ecf-aa18-0dba89e0c54f"
         }
     ],
     "type": "queue"
 }
 ```
 
-
 <h2>Deleting Queue (Store finished cooking)</h2>
 
->http://localhost:8008/dump OR http://127.0.0.1:8008/dump
+>http://localhost:8008/delete OR http://127.0.0.1:8008/delete
 >POST Request
 
 <h3>Expected Payload</h3>
 
 ```json
 {
-    "food" : "Grilled_Teriyaki_Chicken_Donburi",
-    "restaurant" : "Bricklane",
-    "id": "1", //this refers to queue id btw pls don't confuse
-    "action": "delete"
+    "restaurant" : "Nasi_Lemak_Ayam_Taliwang",
+    "order_id" : "909fff87-e51c-4ecf-aa18-0dba89e0c54f"
 }
 ```
 
@@ -200,39 +214,45 @@ Queue Data Succesfully Sent 🚀🚀🚀🚀
 
 >console print
 
+```bash
+Change detected in a table:
+A record was deleted from the "nasi_lemak_ayam_taliwang" table.
+```
+
 ```json
 {
-    "message": "Deleted (➖) Queue from Bricklane",
+    "message": "Deleted (➖) Queue from Nasi_Lemak_Ayam_Taliwang",
     "data": [
         {
-            "id": 8,
-            "food": "Grilled_Teriyaki_Chicken_Donburi",
-            "user_id": "Kendrick",
-            "time": "2025-03-09T16:08:09.483586"
+            "queue_no": 9,
+            "user_id": "Ewan",
+            "time": "2025-03-20T16:43:56.440132",
+            "order_id": "909fff87-e51c-4ecf-aa18-0dba89e0c54f"
         }
     ]
 }
 ```
 
+- This will also send an update to socket.io
+
 >socket.io(server.js) data received
 
 ```json
 {
-    "restaurant": "Bricklane",
+    "restaurant": "Nasi_Lemak_Ayam_Taliwang",
     "data": [
         {
-            "id": 8,
-            "food": "Grilled_Teriyaki_Chicken_Donburi",
-            "user_id": "Kendrick",
-            "time": "2025-03-09T16:08:09.483586"
+            "queue_no": 9,
+            "user_id": "Ewan",
+            "time": "2025-03-20T16:43:56.440132",
+            "order_id": "909fff87-e51c-4ecf-aa18-0dba89e0c54f"
         }
     ],
     "type": "queue"
 }
 ```
-
-
 <br>
 <br>
-<h2>NOTE to self</h2> 
-- See for restraunt if want to send it with the first word captialised or not
+<h2></h2>
+- Add/Deletion of queue will result in the qStatus being sent automatically
+

--- a/backend/socket.io/server.js
+++ b/backend/socket.io/server.js
@@ -83,13 +83,13 @@ async function startServer() {
 
         // Receive data of all the queuen
         socket.on("allQueue", (message) => {
-            console.log("📩 addQueue Message received:", message);
+            console.log("📩 aLLQueue Message received:", message);
 
             //Do smth with this data connect to kong or smth
             sendToKong("/queue/all", message); // Forward to Kong
 
             // Send data back to Queue MS to comfirm message added
-            // io.emit("receivedAllQueue", message);
+            io.emit("receivedAllQueue", message);
         })
 
         // Receive data from added Queue
@@ -100,18 +100,18 @@ async function startServer() {
             sendToKong("/queue/add", message); // Forward to Kong
 
             // Send data back to Queue MS to comfirm message added
-            // io.emit("QAdded", message);
+            io.emit("QAdded", message);
         })
 
         // Receive data from what to delete Queue
         socket.on("deleteQueue", (message) => {
-            console.log("📩 Message received:", message);
+            console.log("📩 deleteQueue Message received:", message);
 
             //Do smth with this data connect to kong or smth
             sendToKong("/queue/delete", message); // Forward to Kong
 
             // Send data back to Queue MS to comfirm message added
-            // io.emit("Qdeleted", message);
+            io.emit("Qdeleted", message);
         })
     });
 


### PR DESCRIPTION
But tldr 
- Standardised queries to only the essentials order_id, restraunt name
- Idea is to use order_id as the unique id for any orders among the queue/orders/notifications
- To access order details consider using get request provided by order ms to query by order id 

What's Working 
- order ms 
- queue ms 

What's not working yet
- complete_order ms 
- integration with credit

Optimistic that i can get it done soonish then integration with frontend can proceed 

Ideas 
- Since all that is being passed around is the orderid allow users to see he/her order history 
- This also means when the notifcation is sent smth like "Your order of 123 is ready come down to Bricklane to collect it!" you're able to click on it and it redirects you to the order details